### PR TITLE
Don't specify RAILS_ENV in containers

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,7 +29,6 @@ services:
     depends_on:
       - mysql
     environment:
-      RAILS_ENV: development
       DATABASE_URL: mysql2://sharetribe:secret@mysql/sharetribe_development
       SPHINX_HOST: worker_and_search
   rails-client-assets:
@@ -46,7 +45,6 @@ services:
     depends_on:
       - mysql
     environment:
-      RAILS_ENV: development
       DATABASE_URL: mysql2://sharetribe:secret@mysql/sharetribe_development
   worker_and_search:
     tty: true
@@ -68,7 +66,6 @@ services:
     depends_on:
       - mysql
     environment:
-      RAILS_ENV: development
       DATABASE_URL: mysql2://sharetribe:secret@mysql/sharetribe_development
       SPHINX_HOST: worker_and_search
   rails-server-assets:
@@ -85,5 +82,4 @@ services:
     depends_on:
       - mysql
     environment:
-      RAILS_ENV: development
       DATABASE_URL: mysql2://sharetribe:secret@mysql/sharetribe_development


### PR DESCRIPTION
When you run the specs in a container some gems fail to get loaded due to the fact that RAILS_ENV is development instead of test. Most of the time you won't think that's the root cause and have a hard time.

It's better to leave it empty so that Rails assumes development mode and RSpec sets test mode when executed.