### PR TITLE
Update rubocop config in sync with upstream

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,3 @@ Style/RegexpLiteral:
 # code.
 Style/FrozenStringLiteralComment:
   Enabled: false
-
-Rails/ActiveRecordOverride:
-  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6888,3 +6888,7 @@ Style/ZeroLengthPredicate:
 # URISchemes: http, https
 Metrics/LineLength:
   Max: 268
+
+Rails/ActiveRecordOverride:
+  Exclude:
+    - 'app/models/landing_page_version/section/base.rb'


### PR DESCRIPTION
In f3cd6dcca we disabled it because it was failing in app/models/landing_page_version/section/base.rb but Sharetribe has it
excluded so we better stay in sync with them to avoid future merge conflicts. Chances are that it also failed for them.