### PR TITLE
Link from conversation thread page to testimonial

### DIFF
--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -120,7 +120,7 @@ class Transaction < ApplicationRecord
   }
   scope :for_testimonials, -> {
     includes(:testimonials, testimonials: [:author, :receiver], listing: :author)
-    .where(current_state: ['confirmed', 'canceled', 'dismissed', 'refunded'])
+    .where(current_state: ['confirmed', 'canceled', 'dismissed', 'refunded', 'free'])
   }
   scope :search_by_party_or_listing_title, ->(pattern) {
     joins(:starter, :listing_author)

--- a/app/views/conversations/_messages_and_form.haml
+++ b/app/views/conversations/_messages_and_form.haml
@@ -9,8 +9,9 @@
       = f.hidden_field :conversation_id
 
       = f.button t("conversations.show.send_reply"), style: "display: inline-block; margin-right: 0.75em"
-      = link_to t("conversations.show.new_testimonial"),
-          new_person_message_feedback_path(@current_user.id, message_id: @transaction)
+      - if @transaction.present?
+        = link_to t("conversations.show.new_testimonial"),
+            new_person_message_feedback_path(@current_user.id, message_id: @transaction.id)
 
 #messages
   = render :partial => "conversations/message", :collection => messages, as: :message_or_action

--- a/app/views/conversations/_messages_and_form.haml
+++ b/app/views/conversations/_messages_and_form.haml
@@ -9,7 +9,7 @@
       = f.hidden_field :conversation_id
 
       = f.button t("conversations.show.send_reply"), style: "display: inline-block; margin-right: 0.75em"
-      - if @transaction.present?
+      - if @transaction.present? && @transaction.current_state == 'free'
         = link_to t("conversations.show.new_testimonial"),
             new_person_message_feedback_path(@current_user.id, message_id: @transaction.id)
 

--- a/app/views/conversations/_messages_and_form.haml
+++ b/app/views/conversations/_messages_and_form.haml
@@ -7,7 +7,10 @@
       = f.label :content, t("conversations.show.write_a_reply")
       = f.text_area :content, :class => "reply_form_text_area"
       = f.hidden_field :conversation_id
-      = f.button t("conversations.show.send_reply")
+
+      = f.button t("conversations.show.send_reply"), style: "display: inline-block; margin-right: 0.75em"
+      = link_to t("conversations.show.new_testimonial"),
+          new_person_message_feedback_path(@current_user.id, message_id: @transaction)
 
 #messages
   = render :partial => "conversations/message", :collection => messages, as: :message_or_action

--- a/app/views/transactions/_details.haml
+++ b/app/views/transactions/_details.haml
@@ -12,8 +12,3 @@
 
       %div{:id => "transaction_status"}
         = render :partial => "transactions/status/status", :locals => { :__transaction_model => @transaction, role: role, is_author: is_author }
-
-        - if @transaction.starter == @current_user
-          = button_to t("conversations.show.new_testimonial"),
-              new_person_message_feedback_path(@current_user.id, message_id: @transaction),
-              :type => "button"

--- a/app/views/transactions/_details.haml
+++ b/app/views/transactions/_details.haml
@@ -12,3 +12,8 @@
 
       %div{:id => "transaction_status"}
         = render :partial => "transactions/status/status", :locals => { :__transaction_model => @transaction, role: role, is_author: is_author }
+
+        - if @transaction.starter == @current_user
+          = button_to t("conversations.show.new_testimonial"),
+              new_person_message_feedback_path(@current_user.id, message_id: @transaction),
+              :type => "button"

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1356,6 +1356,7 @@ ca:
       message_sent_by: "Missatge enviat per"
       message_sent_to: "Missatge enviat a"
       send_reply: "Envia resposta"
+      new_testimonial: "Escriu valoració"
       write_a_reply: "Escriu una resposta:"
       conversation_about_listing: "Amb %{person} sobre %{listing}"
       conversation_with_user: "Amb %{person}"

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1356,7 +1356,7 @@ ca:
       message_sent_by: "Missatge enviat per"
       message_sent_to: "Missatge enviat a"
       send_reply: "Envia resposta"
-      new_testimonial: "Escriu valoració"
+      new_testimonial: "Finalitza transacció"
       write_a_reply: "Escriu una resposta:"
       conversation_about_listing: "Amb %{person} sobre %{listing}"
       conversation_with_user: "Amb %{person}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1355,6 +1355,7 @@ en:
       message_sent_by: "Message sent by"
       message_sent_to: "Message sent to"
       send_reply: "Send reply"
+      new_testimonial: "Write review"
       write_a_reply: "Write a reply:"
       conversation_about_listing: "With %{person} about %{listing}"
       conversation_with_user: "With %{person}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1355,7 +1355,7 @@ en:
       message_sent_by: "Message sent by"
       message_sent_to: "Message sent to"
       send_reply: "Send reply"
-      new_testimonial: "Write review"
+      new_testimonial: "Finish transaction"
       write_a_reply: "Write a reply:"
       conversation_about_listing: "With %{person} about %{listing}"
       conversation_with_user: "With %{person}"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1355,6 +1355,7 @@ es:
       message_sent_by: "Mensaje enviado por"
       message_sent_to: "Mensaje enviado a"
       send_reply: "Enviar respuesta"
+      new_testimonial: "Finaliza transacción"
       write_a_reply: "Escribe una respuesta:"
       conversation_about_listing: "Con %{person} acerca de %{listing}"
       conversation_with_user: "Con %{person}"

--- a/features/conversations/transaction.feature
+++ b/features/conversations/transaction.feature
@@ -24,6 +24,14 @@ Feature: Single transaction
     Then I should see "Drive Me Nuts" within ".message-row:nth-child(1)"
     Then I should see "Finish transaction" within ".message-reply-form"
 
+  Scenario: Buyer can write a testimonial of a free transaction
+    Given there is a listing with title "Massage" from "kassi_testperson1" with category "Services" and with listing shape "Requesting"
+    Given there is a message "Drive Me Nuts" from "kassi_testperson2" about that listing
+    Given I am logged in as "kassi_testperson2"
+    When I visit transaction page of that listing
+    And I follow "Finish transaction"
+    Then I should see "Give feedback to"
+
   Scenario: Buyer sees paid transaction
     Given there is a listing with title "car spare parts" from "kassi_testperson1" with category "Items" and with listing shape "Selling For Profit"
     And the price of that listing is 100.00 EUR
@@ -36,6 +44,7 @@ Feature: Single transaction
     Then I should see "Waiting for Kassi to accept the request. As soon as Kassi accepts, you will be charged." within "#transaction_status"
     Then I should see "Payment authorized: €100" within ".message-row:nth-child(1)"
     Then I should see "Hear, Hear" within ".message-row:nth-child(2)"
+    Then I should not see "Finish transaction"
 
   Scenario: Buyer sees paid transaction per hour
     Given there is a listing with title "Massage" from "kassi_testperson1" with category "Services" and with listing shape "Offering Services"

--- a/features/conversations/transaction.feature
+++ b/features/conversations/transaction.feature
@@ -22,6 +22,7 @@ Feature: Single transaction
     When I visit transaction page of that listing
     Then I should see "Massage" within "h2"
     Then I should see "Drive Me Nuts" within ".message-row:nth-child(1)"
+    Then I should see "Finish transaction" within ".message-reply-form"
 
   Scenario: Buyer sees paid transaction
     Given there is a listing with title "car spare parts" from "kassi_testperson1" with category "Items" and with listing shape "Selling For Profit"

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe Transaction, type: :model do
+  describe '#for_testimonials' do
+    it 'includes transactions in free state' do
+      free_transaction = FactoryGirl.create(:transaction, current_state: 'free')
+      expect(Transaction.for_testimonials).to include(free_transaction)
+    end
+  end
+end


### PR DESCRIPTION
Shows a new link next to the "reply" button on a transaction's conversation, which navigates to the new testimonial page. This way free transactions can also have reviews.

## Missing

- [x] Show link only for free transactions.