### PR TITLE
Persist mysql's container data in a volume

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -22,6 +22,9 @@ class MessagesController < ApplicationController
     @message = Message.new(message_params)
     if @message.save
       Delayed::Job.enqueue(MessageSentJob.new(@message.id, @current_community.id))
+
+      conversation = Conversation.find(params[:message][:conversation_id])
+      AskForTestimonial.new(conversation.transaction, @current_community).call
     else
       flash[:error] = "reply_cannot_be_empty"
     end

--- a/app/controllers/testimonials_controller.rb
+++ b/app/controllers/testimonials_controller.rb
@@ -24,6 +24,7 @@ class TestimonialsController < ApplicationController
   end
 
   def new
+    byebug
     transaction = Transaction.find(params[:message_id])
     testimonial = Testimonial.new
     render(locals: { transaction: transaction, testimonial: testimonial})

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,7 +10,7 @@ services:
       MYSQL_DATABASE: sharetribe_development
       MYSQL_ROOT_PASSWORD: secret
     volumes:
-      - ./tmp/mysql:/var/lib/mysql
+      - mysql:/var/lib/mysql
   web:
     tty: true
     stdin_open: true
@@ -83,3 +83,6 @@ services:
       - mysql
     environment:
       DATABASE_URL: mysql2://sharetribe:secret@mysql/sharetribe_development
+
+volumes:
+   mysql:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,6 +11,7 @@ services:
       MYSQL_ROOT_PASSWORD: secret
     volumes:
       - mysql:/var/lib/mysql
+
   web:
     tty: true
     stdin_open: true
@@ -31,21 +32,7 @@ services:
     environment:
       DATABASE_URL: mysql2://sharetribe:secret@mysql/sharetribe_development
       SPHINX_HOST: worker_and_search
-  rails-client-assets:
-    tty: true
-    stdin_open: true
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
-    command: >
-      bash -c "cd client && npm run build:dev:client"
-    volumes:
-      - .:/opt/app
-      - /opt/app/client/node_modules
-    depends_on:
-      - mysql
-    environment:
-      DATABASE_URL: mysql2://sharetribe:secret@mysql/sharetribe_development
+
   worker_and_search:
     tty: true
     stdin_open: true
@@ -68,6 +55,23 @@ services:
     environment:
       DATABASE_URL: mysql2://sharetribe:secret@mysql/sharetribe_development
       SPHINX_HOST: worker_and_search
+
+  rails-client-assets:
+    tty: true
+    stdin_open: true
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: >
+      bash -c "cd client && npm run build:dev:client"
+    volumes:
+      - .:/opt/app
+      - /opt/app/client/node_modules
+    depends_on:
+      - mysql
+    environment:
+      DATABASE_URL: mysql2://sharetribe:secret@mysql/sharetribe_development
+
   rails-server-assets:
     tty: true
     stdin_open: true


### PR DESCRIPTION
We were storing MySQL's data in the host machine which I suspect is the reason why the DB was being wiped out upon running `docker-compose up` (not sure if always). This made me run `db:setup` every time.

This change stores it in a docker volume named `mysql` in /var/lib/docker/volumes which will persist.